### PR TITLE
Handle Trello rate limit and enable feedback url

### DIFF
--- a/.netlify/functions/ticket.js
+++ b/.netlify/functions/ticket.js
@@ -18,7 +18,7 @@ exports.handler = async function (event, context) {
      *  Returns the name and description of the Trello board that queue belongs to.
      */
     if (httpMethod === 'GET') {
-      const { id, queue: queueId } = queryStringParameters
+      const { id } = queryStringParameters
 
       // return object
       let res = {
@@ -31,16 +31,20 @@ exports.handler = async function (event, context) {
 
       const batchUrls = [
         `/cards/${id}/list?fields=name`,
-        `/cards/${id}`,
-        `/lists/${queueId}/cards`]
+        `/cards/${id}`]
         .join(',')
       const batchAPICall = await axios.get(`https://api.trello.com/1/batch?urls=${batchUrls}&${tokenAndKeyParams}`)
+      //Check if rate limit hit
+      if (batchAPICall.status === 429) { return { statusCode: 429, message: "Trello API rate limit" }; }
+      if (batchAPICall.status !== 200) {
+        return { statusCode: batchAPICall.status, message: "BatchAPICall error" };
+      }
 
-      const [getListofCard, getCardDesc, getCardsOnList] = batchAPICall.data
+      const [getListofCard, getCardDesc] = batchAPICall.data
 
       //Check that all Batch apis returned 200
-      if (!getListofCard['200'] || !getCardDesc['200'] || !getCardsOnList['200']) {
-        return { statusCode: 400, message: "Batch error" };
+      if (!getListofCard['200'] || !getCardDesc['200']) {
+        return { statusCode: 400, message: "BatchAPICall subrequest error" };
       }
 
       const { id: newQueueId, name: queueName } = getListofCard['200']
@@ -50,10 +54,18 @@ exports.handler = async function (event, context) {
       const { desc } = getCardDesc['200']
       if (desc !== '') res.ticketDesc = JSON.parse(desc)
 
+      // Get the card's position in the current queue
+      const getCardsOnList = await axios.get(
+        `https://api.trello.com/1/lists/${newQueueId}/cards?key=${TRELLO_KEY}&token=${TRELLO_TOKEN}`)
+
+      if (getCardsOnList.status === 429) { return { statusCode: 429, message: "Trello API rate limit" } }
+      if (getCardsOnList.status !== 200) { return { statusCode: getCardsOnList.status, message: "getCardsOnList error" } }
+
+
       //If list isn't any of the special markers, check for position
       if (!(queueName.includes('[ALERT]') || queueName.includes('[DONE]') || queueName.includes('[MISSED]'))) {
         // To check position in queue
-        const ticketsInQueue = getCardsOnList['200']
+        const ticketsInQueue = getCardsOnList.data
         res.numberOfTicketsAhead = ticketsInQueue.findIndex(val => val.id === id)
       }
 

--- a/.netlify/functions/ticket.js
+++ b/.netlify/functions/ticket.js
@@ -56,7 +56,7 @@ exports.handler = async function (event, context) {
 
       // Get the card's position in the current queue
       const getCardsOnList = await axios.get(
-        `https://api.trello.com/1/lists/${newQueueId}/cards?key=${TRELLO_KEY}&token=${TRELLO_TOKEN}`)
+        `https://api.trello.com/1/lists/${newQueueId}/cards?${tokenAndKeyParams}`)
 
       if (getCardsOnList.status === 429) { return { statusCode: 429, message: "Trello API rate limit" } }
       if (getCardsOnList.status !== 200) { return { statusCode: getCardsOnList.status, message: "getCardsOnList error" } }

--- a/src/components/Ticket/Served.js
+++ b/src/components/Ticket/Served.js
@@ -1,17 +1,14 @@
 import {
   Box,
-  Button,
   Center,
-  Heading,
   Text,
-  theme,
-  Flex
+  Flex,
 } from '@chakra-ui/react'
 import useTranslation from 'next-translate/useTranslation'
 
 import LadyHoldingPhone from '../../assets/svg/lady-holding-phone.svg'
 
-export const Served = ({ }) => {
+export const Served = ({ feedbackLink }) => {
   const { t } = useTranslation('common')
 
   return <>
@@ -39,6 +36,13 @@ export const Served = ({ }) => {
       >
         {t('wish-you-good-day-ahead')}
       </Text>
+
+      {feedbackLink && <Text
+        textStyle="body1"
+        mt={4}
+        textDecoration="underline"
+      ><a href={feedbackLink}>Give us some feedback</a>
+      </Text>}
     </Box>
   </>
 }

--- a/src/pages/queue.js
+++ b/src/pages/queue.js
@@ -87,7 +87,7 @@ const Index = () => {
       setRegistrationFields(boardInfo.registrationFields)
       setFeedbackLink(boardInfo.feedbackLink)
     } catch (err) {
-      console.log(err.response.status);
+      console.log(err);
     }
   }
 

--- a/src/pages/queue.js
+++ b/src/pages/queue.js
@@ -87,7 +87,7 @@ const Index = () => {
       setMessage(boardInfo.message)
       setRegistrationFields(boardInfo.registrationFields)
     } catch (err) {
-      console.log(err.response);
+      console.log(err.response.status);
     }
   }
 
@@ -123,7 +123,7 @@ const Index = () => {
       const url = `/ticket?queue=${query.id}&ticket=${ticketId}&ticketNumber=${ticketNumber}`
       router.push(url, url, { locale: lang })
     } catch (err) {
-      console.log(err.response)
+      console.log(err.response.status);
       setIsSubmitting(false)
     }
   }

--- a/src/pages/queue.js
+++ b/src/pages/queue.js
@@ -26,7 +26,7 @@ const Index = () => {
   const [cookies, setCookie] = useCookies(['ticket']);
 
   const [boardName, setBoardName] = useState('')
-  const [message, setMessage] = useState('')
+  const [feedbackLink, setFeedbackLink] = useState()
   const [registrationFields, setRegistrationFields] = useState([])
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [invalidNRIC, setInvalidNRIC] = useState(false)
@@ -84,8 +84,8 @@ const Index = () => {
       const { name, desc } = getBoardQueueBelongsTo.data
       setBoardName(name)
       const boardInfo = JSON.parse(desc)
-      setMessage(boardInfo.message)
       setRegistrationFields(boardInfo.registrationFields)
+      setFeedbackLink(boardInfo.feedbackLink)
     } catch (err) {
       console.log(err.response.status);
     }
@@ -120,7 +120,8 @@ const Index = () => {
       const query = queryString.parse(location.search);
       const postJoinQueue = await axios.post(`/.netlify/functions/ticket?queue=${query.id}`, { desc: desc })
       const { ticketId, ticketNumber } = postJoinQueue.data
-      const url = `/ticket?queue=${query.id}&ticket=${ticketId}&ticketNumber=${ticketNumber}`
+      const feedback = feedbackLink ? `&feedback=${encodeURIComponent(feedbackLink)}` : ''
+      const url = `/ticket?queue=${query.id}&ticket=${ticketId}&ticketNumber=${ticketNumber}${feedback}`
       router.push(url, url, { locale: lang })
     } catch (err) {
       console.log(err.response.status);

--- a/src/pages/ticket.js
+++ b/src/pages/ticket.js
@@ -39,6 +39,7 @@ const Index = () => {
   const [ticketNumber, setTicketNumber] = useState()
   const [displayTicketInfo, setDisplayTicketInfo] = useState('')
   const [lastUpdated, setLastUpdated] = useState('')
+  const [feedbackLink, setFeedbackLink] = useState()
 
   const [cookies, setCookie, removeCookie] = useCookies(['ticket']);
 
@@ -58,6 +59,8 @@ const Index = () => {
         ticket: query.ticket,
         ticketNumber: query.ticketNumber
       })
+      //Save feedback link
+      if (query.feedback) setFeedbackLink(query.feedback)
     }
   }, [])
 
@@ -145,7 +148,7 @@ const Index = () => {
     }
     // 2. Served - Ticket is complete
     else if (ticketState === TICKET_STATUS.SERVED) {
-      return <Served />
+      return <Served feedbackLink={feedbackLink} />
     }
     // 3. Missed - Ticket is in [MISSED] / not in the queue / queue doesnt exist
     else if (ticketState === TICKET_STATUS.MISSED) {


### PR DESCRIPTION
- Fix bug of queue not found when queue changes
- Split api call into 2 to ensure polling correct queue
- Gracefully handle trello rate limiting (429) and simply wait for the next interval
- Read feedback url from board description and show on completion if it exists