### PR TITLE
feat: automatic rejoins based on number

### DIFF
--- a/.netlify/functions/queue.js
+++ b/.netlify/functions/queue.js
@@ -6,7 +6,7 @@ const axios = require('axios');
 exports.handler = async function (event, context) {
   try {
     const { httpMethod, queryStringParameters, body } = event
-    const { TRELLO_KEY, TRELLO_TOKEN, IS_PUBLIC_BOARD } = process.env
+    const { TRELLO_KEY, TRELLO_TOKEN, IS_PUBLIC_BOARD, TRELLO_ENDPOINT } = process.env
     const tokenAndKeyParams = IS_PUBLIC_BOARD === 'true' ? '' : `key=${TRELLO_KEY}&token=${TRELLO_TOKEN}`
 
     /**
@@ -18,7 +18,7 @@ exports.handler = async function (event, context) {
     if (httpMethod === 'GET') {
       const { id } = queryStringParameters
 
-      const getBoardQueueBelongsTo = await axios.get(`https://api.trello.com/1/lists/${id}/board?fields=id,name,desc&${tokenAndKeyParams}`)
+      const getBoardQueueBelongsTo = await axios.get(`${TRELLO_ENDPOINT}/lists/${id}/board?fields=id,name,desc&${tokenAndKeyParams}`)
       const { name, desc } = getBoardQueueBelongsTo.data
 
       return {

--- a/.netlify/functions/ticket.js
+++ b/.netlify/functions/ticket.js
@@ -103,6 +103,22 @@ exports.handler = async function (event, context) {
 
       const queue = queryStringParameters.queue
       if (queue) {
+
+        // if contact is provided, search pending queue for duplicate number
+        if (contact) {
+          const getCardsOnPendingList = await axios.get(`https://api.trello.com/1/lists/${queue}/cards?key=${TRELLO_KEY}&token=${TRELLO_TOKEN}`)
+          const ticketsInQueue = getCardsOnPendingList.data
+
+          const match = ticketsInQueue.find(ticket => ticket.name.includes(contact))
+          // If match found return that ticket info instead of creating a new one
+          if (match) {
+            return {
+              statusCode: 200,
+              body: JSON.stringify({ ticketId: match.id, ticketNumber: match.idShort })
+            };
+          }
+        }
+
         const createCard = await axios.post(
           `https://api.trello.com/1/cards?key=${TRELLO_KEY}&token=${TRELLO_TOKEN}&idList=${queue}&desc=${descString}`)
 

--- a/.netlify/functions/ticket.js
+++ b/.netlify/functions/ticket.js
@@ -13,7 +13,6 @@ exports.handler = async function (event, context) {
      * GET /ticket
      * - Retrieves info about a ticket and its position in queue
      * @param  {string} id The id of the ticket
-     * @param  {string} queue The id of the queue
      * @return {queueId: string, queueName: string, ticketId: string, ticketDesc: string, numberOfTicketsAhead: Number}
      *  Returns the name and description of the Trello board that queue belongs to.
      */
@@ -32,7 +31,6 @@ exports.handler = async function (event, context) {
       const batchUrls = [
         `/cards/${id}/list?fields=name`,
         `/cards/${id}`,
-        `/cards/${id}/board`
       ].join(',')
       const batchAPICall = await axios.get(`${TRELLO_ENDPOINT}/batch?urls=${batchUrls}&${tokenAndKeyParams}`)
 
@@ -42,10 +40,10 @@ exports.handler = async function (event, context) {
         return { statusCode: batchAPICall.status, message: "BatchAPICall error" };
       }
 
-      const [getListofCard, getCardDesc, getCardBoard] = batchAPICall.data
+      const [getListofCard, getCardDesc] = batchAPICall.data
 
       //Check that all Batch apis returned 200
-      if (!getListofCard['200'] || !getCardDesc['200'] || !getCardBoard['200']) {
+      if (!getListofCard['200'] || !getCardDesc['200']) {
         return { statusCode: 400, message: "BatchAPICall subrequest error" };
       }
 
@@ -69,13 +67,6 @@ exports.handler = async function (event, context) {
         // To check position in queue
         const ticketsInQueue = getCardsOnList.data
         res.numberOfTicketsAhead = ticketsInQueue.findIndex(val => val.id === id)
-      }
-
-      //  Board information
-      // console.log(getCardBoard['200'])
-      res.board = {
-        id: getCardBoard['200'].id,
-        name: getCardBoard['200'].name,
       }
 
       return {

--- a/.netlify/functions/ticket.js
+++ b/.netlify/functions/ticket.js
@@ -106,7 +106,7 @@ exports.handler = async function (event, context) {
 
         // if contact is provided, search pending queue for duplicate number
         if (contact) {
-          const getCardsOnPendingList = await axios.get(`${TRELLO_ENDPOINT}/lists/${queue}/cards?key=${TRELLO_KEY}&token=${TRELLO_TOKEN}`)
+          const getCardsOnPendingList = await axios.get(`${TRELLO_ENDPOINT}/lists/${queue}/cards?${tokenAndKeyParams}`)
           const ticketsInQueue = getCardsOnPendingList.data
 
           const match = ticketsInQueue.find(ticket => ticket.name.includes(contact))
@@ -120,13 +120,13 @@ exports.handler = async function (event, context) {
         }
 
         const createCard = await axios.post(
-          `${TRELLO_ENDPOINT}/cards?key=${TRELLO_KEY}&token=${TRELLO_TOKEN}&idList=${queue}&desc=${descString}`)
+          `${TRELLO_ENDPOINT}/cards?${tokenAndKeyParams}&idList=${queue}&desc=${descString}`)
 
         const { id, idShort } = createCard.data
         const cardName = `${idShort}${name}${contact}${category}`
         // Update newly created card with number{-name}{-contact}{-category} and desc
         await axios.put(
-          `${TRELLO_ENDPOINT}/cards/${id}?key=${TRELLO_KEY}&token=${TRELLO_TOKEN}&name=${cardName}`)
+          `${TRELLO_ENDPOINT}/cards/${id}?${tokenAndKeyParams}&name=${cardName}`)
 
         return {
           statusCode: 200,
@@ -144,7 +144,7 @@ exports.handler = async function (event, context) {
     else if (httpMethod === 'PUT') {
       const { id, queue } = queryStringParameters
       if (id && queue) {
-        await axios.put(`${TRELLO_ENDPOINT}/cards/${id}?key=${TRELLO_KEY}&token=${TRELLO_TOKEN}&idList=${queue}&pos=bottom`)
+        await axios.put(`${TRELLO_ENDPOINT}/cards/${id}?${tokenAndKeyParams}&idList=${queue}&pos=bottom`)
       }
       return {
         statusCode: 200,
@@ -162,7 +162,7 @@ exports.handler = async function (event, context) {
     else if (httpMethod === 'DELETE') {
       const id = queryStringParameters.id
       if (id) {
-        await axios.delete(`${TRELLO_ENDPOINT}/cards/${id}?key=${TRELLO_KEY}&token=${TRELLO_TOKEN}`)
+        await axios.delete(`${TRELLO_ENDPOINT}/cards/${id}?${tokenAndKeyParams}`)
       }
       return {
         statusCode: 200,

--- a/.netlify/functions/ticket.js
+++ b/.netlify/functions/ticket.js
@@ -96,8 +96,9 @@ exports.handler = async function (event, context) {
     else if (httpMethod === 'POST') {
       const { desc } = JSON.parse(body)
 
-      const name = desc.name || 'unknown user'
-      const category = desc.category
+      const name = desc.name ? `-${desc.name}` : ''
+      const contact = desc.contact ? `-${desc.contact}` : ''
+      const category = desc.category ? `-${desc.category}` : ''
       const descString = JSON.stringify(desc)
 
       const queue = queryStringParameters.queue
@@ -106,9 +107,10 @@ exports.handler = async function (event, context) {
           `https://api.trello.com/1/cards?key=${TRELLO_KEY}&token=${TRELLO_TOKEN}&idList=${queue}&desc=${descString}`)
 
         const { id, idShort } = createCard.data
-        // Update newly created card with number-name{-category} and desc
+        const cardName = `${idShort}${name}${contact}${category}`
+        // Update newly created card with number{-name}{-contact}{-category} and desc
         await axios.put(
-          `https://api.trello.com/1/cards/${id}?key=${TRELLO_KEY}&token=${TRELLO_TOKEN}&name=${idShort}-${name}${category ? '-'+category : ''}`)
+          `https://api.trello.com/1/cards/${id}?key=${TRELLO_KEY}&token=${TRELLO_TOKEN}&name=${cardName}`)
 
         return {
           statusCode: 200,

--- a/.netlify/functions/view.js
+++ b/.netlify/functions/view.js
@@ -6,7 +6,7 @@ const axios = require('axios');
 exports.handler = async function (event, context) {
   try {
     const { httpMethod, queryStringParameters, body } = event
-    const { TRELLO_KEY, TRELLO_TOKEN, IS_PUBLIC_BOARD } = process.env
+    const { TRELLO_KEY, TRELLO_TOKEN, IS_PUBLIC_BOARD, TRELLO_ENDPOINT } = process.env
     const tokenAndKeyParams = IS_PUBLIC_BOARD === 'true' ? '' : `key=${TRELLO_KEY}&token=${TRELLO_TOKEN}`
 
     /**
@@ -26,10 +26,10 @@ exports.handler = async function (event, context) {
       let res = {}
       const { type } = queryStringParameters
       if (type === 'board' && queryStringParameters.board) {
-        const board = await axios.get(`https://api.trello.com/1/boards/${queryStringParameters.board}?${tokenAndKeyParams}`)
+        const board = await axios.get(`${TRELLO_ENDPOINT}/boards/${queryStringParameters.board}?${tokenAndKeyParams}`)
         res = board.data
       } else if (type === 'boardlists' && queryStringParameters.board) {
-        const boardLists = await axios.get(`https://api.trello.com/1/boards/${queryStringParameters.board}/lists?${tokenAndKeyParams}`)
+        const boardLists = await axios.get(`${TRELLO_ENDPOINT}/boards/${queryStringParameters.board}/lists?${tokenAndKeyParams}`)
         res = boardLists.data
       } else if (type === 'queues' && queryStringParameters.queueAlertIds && queryStringParameters.queueMissedId) {
 
@@ -41,13 +41,13 @@ exports.handler = async function (event, context) {
         })
 
         const batchUrls = setOfBatchUrls.join(',')
-        const batchAPICall = await axios.get(`https://api.trello.com/1/batch?urls=${batchUrls}&${tokenAndKeyParams}`)
-        
+        const batchAPICall = await axios.get(`${TRELLO_ENDPOINT}/batch?urls=${batchUrls}&${tokenAndKeyParams}`)
+
         const [missedQueue, ...rest] = batchAPICall.data
-        
+
         //Check that all Batch apis returned 200
         const allAlertQueues = rest.filter(queue => Object.keys(queue)[0] === '200')
-        
+
         if (allAlertQueues.length !== queueAlertIds.length || !missedQueue['200']) {
           return { statusCode: 400, message: "Batch error" }
         };

--- a/.netlify/functions/view.js
+++ b/.netlify/functions/view.js
@@ -14,24 +14,32 @@ exports.handler = async function (event, context) {
      * - Retrieves info about a ticket and its position in queue
      * @param  {string} type The type of board data to retrieve
      * There are 3 types of api calls:
-     * 1. board - Retrieves data about the board
-     * *  @param  {string} board The board id
-     * 2. boardlists - Retrieves all the lists that a board contains
-     * *  @param  {string} board The board id
-     * 3. queues - Retrieve specifically the cards in Alert and Missed queues
-     * *  @param  {string} queueAlertIds Comma delimited set of ids of the Alert queues
-     * *  @param  {string} queueMissedId The id of the Missed queue
      */
     if (httpMethod === 'GET') {
       let res = {}
       const { type } = queryStringParameters
+      /**
+       * 1. board - Retrieves data about the board
+       * *  @param  {string} board The board id
+      */
       if (type === 'board' && queryStringParameters.board) {
         const board = await axios.get(`${TRELLO_ENDPOINT}/boards/${queryStringParameters.board}?${tokenAndKeyParams}`)
         res = board.data
-      } else if (type === 'boardlists' && queryStringParameters.board) {
+      }
+      /**
+       * 2. boardlists - Retrieves all the lists that a board contains
+       * *  @param  {string} board The board id
+      */
+      else if (type === 'boardlists' && queryStringParameters.board) {
         const boardLists = await axios.get(`${TRELLO_ENDPOINT}/boards/${queryStringParameters.board}/lists?${tokenAndKeyParams}`)
         res = boardLists.data
-      } else if (type === 'queues' && queryStringParameters.queueAlertIds && queryStringParameters.queueMissedId) {
+      }
+      /**
+       * 3. queues - Retrieve specifically the cards in Alert and Missed queues
+       * *  @param  {string} queueAlertIds Comma delimited set of ids of the Alert queues
+       * *  @param  {string} queueMissedId The id of the Missed queue
+      */
+      else if (type === 'queues' && queryStringParameters.queueAlertIds && queryStringParameters.queueMissedId) {
 
         const queueAlertIds = queryStringParameters.queueAlertIds.split(',')
         const setOfBatchUrls = [`/lists/${queryStringParameters.queueMissedId}/cards`]

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -4,7 +4,7 @@ export const Main = (props) => (
   <Stack
     w="400px"
     maxW="100%"
-    px={2}
+    px={4}
     minHeight="calc(100vh - 84px)"
     justifyContent="space-evenly"
     {...props}

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -3,9 +3,12 @@ import { useRouter } from 'next/router'
 import Link from 'next/link'
 
 import LogoQueue from '../assets/svg/logo-queue.svg'
+import useTranslation from 'next-translate/useTranslation'
 
 export const NavBar = (props) => {
   const router = useRouter()
+
+  const { t, lang } = useTranslation('common')
 
 
   const languages = [
@@ -33,13 +36,14 @@ export const NavBar = (props) => {
       align="center"
       justify="space-between"
       maxW="100%"
+      width="400px"
       pt={4}
       pb={8}
       px={4}
       bg="base.100"
       color={"white"}
       {...props}>
-      <Box w="100px">
+      <Box>
         <a href="/">
           <LogoQueue
             height="40px"
@@ -47,10 +51,7 @@ export const NavBar = (props) => {
           />
         </a>
       </Box>
-      <Box
-        display={"block"}
-        flexBasis={"auto"}
-      >
+      <Box>
         {languages.map((lng, idx) => (
           <>
             {idx > 0 && <span style={{ color: "#636467" }} >|</span>}
@@ -59,7 +60,7 @@ export const NavBar = (props) => {
               href={`${router.asPath}`}
               locale={lng.locale}
             >
-              <Button textColor="#636467" variant="link" mx={1}>
+              <Button textColor="#636467" variant="link" mx={1} fontSize='14px' textDecoration={t('lang') === lng.name ? 'underline' : 'none'}>
                 {lng.name}
               </Button>
             </Link>

--- a/src/components/Support/GenerateUrls.js
+++ b/src/components/Support/GenerateUrls.js
@@ -9,7 +9,7 @@ import axios from 'axios'
 import { useState } from 'react'
 
 import { UrlInput } from './UrlInput'
-import { QUEUE_TITLES } from '../../constants'
+import { NETLIFY_FN_ENDPOINT, QUEUE_TITLES } from '../../constants'
 
 export const GenerateUrls = () => {
   const [rootUrl, setRootUrl] = useState('')
@@ -23,9 +23,9 @@ export const GenerateUrls = () => {
    */
   const getBoard = async () => {
     try {
-      const boardLists = await axios.get(`/.netlify/functions/view?type=boardlists&board=${boardId}`)
+      const boardLists = await axios.get(`${NETLIFY_FN_ENDPOINT}/view?type=boardlists&board=${boardId}`)
       boardLists.data.forEach(list => {
-        if(list.name.indexOf(QUEUE_TITLES.PENDING) > -1) {
+        if (list.name.indexOf(QUEUE_TITLES.PENDING) > -1) {
           setQueueId(list.id)
         }
       })
@@ -69,11 +69,11 @@ export const GenerateUrls = () => {
         isInvalid={formError}
       />
       {
-        formError !== null 
-        ?
-        <Text textStyle="body2" color="error.500">{ formError }</Text>
-        :
-        null
+        formError !== null
+          ?
+          <Text textStyle="body2" color="error.500">{formError}</Text>
+          :
+          null
       }
       <Button
         bgColor="primary.500"
@@ -104,8 +104,8 @@ export const GenerateUrls = () => {
       </Text>
       <UrlInput
         url={`${rootUrl}/queue?id=${queueId}`}
-        />
-      
+      />
+
       <Text
         pt={4}
         pb="0.5rem"
@@ -115,7 +115,7 @@ export const GenerateUrls = () => {
       </Text>
       <UrlInput
         url={`${rootUrl}/qr?queue=${queueId}`}
-        />
+      />
 
       <Text
         pt={4}
@@ -126,7 +126,7 @@ export const GenerateUrls = () => {
       </Text>
       <UrlInput
         url={`${rootUrl}/view?board=${boardId}`}
-        /> 
+      />
     </Flex>
   }
 
@@ -134,7 +134,7 @@ export const GenerateUrls = () => {
     <Box
       w="800px"
       layerStyle="card"
-      >
+    >
       {
         queueId && boardId ?
           renderQueueUrls() :

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,7 @@
 export const NETLIFY_FN_ENDPOINT = '/.netlify/functions'
 
+export const COOKIE_MAX_AGE = 60 * 90
+
 export const BOARD_ID = process.env.NEXT_PUBLIC_TRELLO_BOARD_ID || ''
 
 export const TICKET_STATUS = {

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,5 @@
+export const NETLIFY_FN_ENDPOINT = '/.netlify/functions'
+
 export const BOARD_ID = process.env.NEXT_PUBLIC_TRELLO_BOARD_ID || ''
 
 export const TICKET_STATUS = {

--- a/src/pages/admin/index.js
+++ b/src/pages/admin/index.js
@@ -362,7 +362,7 @@ const Index = () => {
         <title>Admin - QueueUp Sg</title>
       </Head>
       <Container>
-        <Navbar width="100%" />
+        <Navbar />
         <Main justifyContent="start" minHeight="90vh" width="100%">
           <Center>
             {/* TODO: migrate to components for sanity */}

--- a/src/pages/admin/login.js
+++ b/src/pages/admin/login.js
@@ -26,6 +26,7 @@ import {
 } from '../../components/Admin'
 
 import ManWithHourglass from "../../assets/svg/man-with-hourglass.svg"
+import { NETLIFY_FN_ENDPOINT } from '../../constants'
 
 const Index = () => {
   const { isOpen, onOpen, onClose } = useDisclosure()
@@ -35,7 +36,7 @@ const Index = () => {
   useEffect(() => {
     const query = queryString.parse(location.search)
     setBoardId(query.boardId)
-  },[])
+  }, [])
 
   const updateBoardId = (e) => {
     setBoardId(e.target.value)
@@ -49,7 +50,7 @@ const Index = () => {
     if (boardId) {
       try {
         setIsLoading(true)
-        const response = await axios.post(`/.netlify/functions/login`, {
+        const response = await axios.post(`${NETLIFY_FN_ENDPOINT}/login`, {
           boardId,
         })
         if (response.data.authorizeUrl) {
@@ -87,7 +88,7 @@ const Index = () => {
           >
             <form
               onSubmit={authoriseApp}
-              >
+            >
               <InputText
                 id="boardId"
                 label="Board ID"
@@ -99,7 +100,7 @@ const Index = () => {
                   </Text>
                 }
                 value={boardId}
-                />
+              />
 
               <Button
                 flex
@@ -126,7 +127,7 @@ const Index = () => {
           <ModalCloseButton />
           <ModalBody>
             <Text>
-              If the URL to your trello board is 
+              If the URL to your trello board is
               <Box bg="gray.200" p="2" my="5">
                 <Text fontSize="xs"><code flex>https://trello.com/b/<Box display="inline" bg="primary.500" color="white">zlksMWQT</Box>/psd-center-at-tampines</code></Text>
               </Box>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -17,6 +17,7 @@ import { Footer } from '../components/Footer'
 import { NavBar } from '../components/Navbar'
 
 import PeopleOnPhones from '../assets/svg/people-on-phones.svg'
+import { NETLIFY_FN_ENDPOINT } from '../constants'
 
 const Index = () => {
   const { t, lang } = useTranslation('common')
@@ -39,7 +40,7 @@ const Index = () => {
   const getBoardLists = async (boardId) => {
     if (boardId) {
       try {
-        const boardLists = await axios.get(`/.netlify/functions/view?type=boardlists&board=${boardId}`)
+        const boardLists = await axios.get(`${NETLIFY_FN_ENDPOINT}/view?type=boardlists&board=${boardId}`)
         boardLists.data.forEach(list => {
           if (list.name.indexOf('[PENDING]') > -1) {
             setQueuePendingUrl(location.origin + `/queue?id=${list.id}`)

--- a/src/pages/qr.js
+++ b/src/pages/qr.js
@@ -14,6 +14,7 @@ import { Container } from '../components/Container'
 import { Main } from '../components/Main'
 import { NavBar } from '../components/Navbar'
 import PeopleOnPhones from '../assets/svg/people-on-phones.svg'
+import { NETLIFY_FN_ENDPOINT } from '../constants'
 const Index = () => {
   const [url, setUrl] = useState('')
   const [boardName, setBoardName] = useState('')
@@ -31,7 +32,7 @@ const Index = () => {
       // Get the board queue belongs to this
       // 1. Verifies that queue actually exists
       // 2. Gets info stored as JSON in board description
-      const getBoardQueueBelongsTo = await axios.get(`/.netlify/functions/queue?id=${queue}`)
+      const getBoardQueueBelongsTo = await axios.get(`${NETLIFY_FN_ENDPOINT}/queue?id=${queue}`)
       const { name } = getBoardQueueBelongsTo.data
       setBoardName(name)
     } catch (err) {
@@ -42,7 +43,7 @@ const Index = () => {
   return (
     <>
       <Head>
-        <title>{ boardName }</title>
+        <title>{boardName}</title>
       </Head>
       <Container>
         <NavBar width="100%" maxWidth="600px" />
@@ -61,7 +62,7 @@ const Index = () => {
               textStyle="display2"
             >
               Scan QR Code to join the queue
-          </Heading>
+            </Heading>
           </Box>
           <Box
             layerStyle="card"

--- a/src/pages/queue.js
+++ b/src/pages/queue.js
@@ -29,6 +29,7 @@ import {
 } from '@chakra-ui/react'
 import { useCookies } from 'react-cookie';
 import useTranslation from 'next-translate/useTranslation'
+import { NETLIFY_FN_ENDPOINT } from '../constants'
 
 const Index = () => {
   const { t, lang } = useTranslation('common')
@@ -96,7 +97,7 @@ const Index = () => {
       // Get the board queue belongs to this
       // 1. Verifies that queue actually exists
       // 2. Gets info stored as JSON in board description
-      const getBoardQueueBelongsTo = await axios.get(`/.netlify/functions/queue?id=${queueId}`)
+      const getBoardQueueBelongsTo = await axios.get(`${NETLIFY_FN_ENDPOINT}/queue?id=${queueId}`)
       const { name, desc } = getBoardQueueBelongsTo.data
 
       const boardInfo = JSON.parse(desc)
@@ -167,7 +168,7 @@ const Index = () => {
       // call netlify function to create a ticket
       // for that queue, return the ticket id and redirect to ticket page
       const query = queryString.parse(location.search);
-      const postJoinQueue = await axios.post(`/.netlify/functions/ticket?queue=${query.id}`, { desc })
+      const postJoinQueue = await axios.post(`${NETLIFY_FN_ENDPOINT}/ticket?queue=${query.id}`, { desc })
       const { ticketId, ticketNumber } = postJoinQueue.data
       const feedback = feedbackLink ? `&feedback=${encodeURIComponent(feedbackLink)}` : ''
       const waitTime = `&waitTimePerTicket=${encodeURIComponent(waitTimePerTicket)}`
@@ -284,7 +285,7 @@ const Index = () => {
                     textStyle="subtitle1"
                   >
                     NRIC
-            </Text>
+                  </Text>
                   <Input
                     layerStyle="formInput"
                     isInvalid={invalidNRIC && "error.500"}
@@ -373,7 +374,7 @@ const Index = () => {
     <Container>
       <NavBar />
       <Main>
-        { render() }
+        {render()}
       </Main>
       <Footer />
     </Container>

--- a/src/pages/ticket.js
+++ b/src/pages/ticket.js
@@ -13,7 +13,7 @@ import axios from 'axios'
 import { useCookies } from 'react-cookie'
 
 import { useInterval } from '../utils'
-import { NETLIFY_FN_ENDPOINT, TICKET_STATUS } from '../constants'
+import { COOKIE_MAX_AGE, NETLIFY_FN_ENDPOINT, TICKET_STATUS } from '../constants'
 import { Container } from '../components/Container'
 import { Main } from '../components/Main'
 import { Footer } from '../components/Footer'
@@ -60,7 +60,7 @@ const Index = () => {
         queue: query.queue,
         ticket: query.ticket,
         ticketNumber: query.ticketNumber
-      })
+      }, { maxAge: COOKIE_MAX_AGE })
       //Save feedback link
       if (query.feedback) setFeedbackLink(query.feedback)
 

--- a/src/pages/ticket.js
+++ b/src/pages/ticket.js
@@ -38,7 +38,6 @@ const Index = () => {
   const [ticketId, setTicketId] = useState()
   const [queueId, setQueueId] = useState()
   const [queueName, setQueueName] = useState()
-  const [board, setBoard] = useState()
   const [ticketNumber, setTicketNumber] = useState()
   const [displayTicketInfo, setDisplayTicketInfo] = useState('')
   const [lastUpdated, setLastUpdated] = useState('')
@@ -79,8 +78,7 @@ const Index = () => {
   const getTicketStatus = async (ticket) => {
     try {
       const getTicket = await axios.get(`${NETLIFY_FN_ENDPOINT}/ticket?id=${ticket}`)
-      const { queueId, queueName, ticketDesc, numberOfTicketsAhead, board } = getTicket.data
-      setBoard(board)
+      const { queueId, queueName, ticketDesc, numberOfTicketsAhead } = getTicket.data
       //Update queueId in case ticket has been shifted
       setQueueId(queueId)
 
@@ -198,7 +196,7 @@ const Index = () => {
   return (
     <>
       <Head>
-        <title>{board ? board.name : 'QueueUp SG'}</title>
+        <title>QueueUp SG</title>
       </Head>
       <Container>
         <LeaveModal isOpen={isOpen} onOpen={onOpen} onClose={onClose} leaveQueue={leaveQueue} />

--- a/src/pages/ticket.js
+++ b/src/pages/ticket.js
@@ -13,7 +13,7 @@ import axios from 'axios'
 import { useCookies } from 'react-cookie'
 
 import { useInterval } from '../utils'
-import { TICKET_STATUS } from '../constants'
+import { NETLIFY_FN_ENDPOINT, TICKET_STATUS } from '../constants'
 import { Container } from '../components/Container'
 import { Main } from '../components/Main'
 import { Footer } from '../components/Footer'
@@ -78,7 +78,7 @@ const Index = () => {
 
   const getTicketStatus = async (ticket) => {
     try {
-      const getTicket = await axios.get(`/.netlify/functions/ticket?id=${ticket}`)
+      const getTicket = await axios.get(`${NETLIFY_FN_ENDPOINT}/ticket?id=${ticket}`)
       const { queueId, queueName, ticketDesc, numberOfTicketsAhead, board } = getTicket.data
       setBoard(board)
       //Update queueId in case ticket has been shifted
@@ -128,7 +128,7 @@ const Index = () => {
 
   const leaveQueue = async () => {
     try {
-      axios.delete(`/.netlify/functions/ticket?id=${ticketId}`)
+      axios.delete(`${NETLIFY_FN_ENDPOINT}/ticket?id=${ticketId}`)
       removeCookie('ticket')
       router.push(`/`)
     } catch (error) {
@@ -140,7 +140,7 @@ const Index = () => {
     const query = queryString.parse(location.search);
     if (query.queue) {
       // NOTE: Using query string queue as that is the initial queue not the current queue
-      await axios.put(`/.netlify/functions/ticket?id=${ticketId}&queue=${query.queue}`)
+      await axios.put(`${NETLIFY_FN_ENDPOINT}/ticket?id=${ticketId}&queue=${query.queue}`)
       getTicketStatus(query.ticket, query.queue)
     }
   }

--- a/src/pages/view.js
+++ b/src/pages/view.js
@@ -6,7 +6,7 @@ import Head from 'next/head'
 import { useEffect, useState } from 'react'
 import queryString from 'query-string'
 import axios from 'axios'
-import { QUEUE_TITLES } from '../constants'
+import { NETLIFY_FN_ENDPOINT, QUEUE_TITLES } from '../constants'
 import { useInterval } from '../utils'
 import { CurrentlyServingQueue } from '../components/View/CurrentlyServingQueue'
 import { MissedQueue } from '../components/View/MissedQueue'
@@ -44,7 +44,7 @@ const Index = () => {
   const getBoard = async (boardId) => {
     if (boardId) {
       try {
-        const board = await axios.get(`/.netlify/functions/view?type=board&board=${boardId}`)
+        const board = await axios.get(`${NETLIFY_FN_ENDPOINT}/view?type=board&board=${boardId}`)
         setBoard(board.data)
       } catch (error) {
         console.error(error)
@@ -58,8 +58,8 @@ const Index = () => {
   const getBoardLists = async (boardId) => {
     if (boardId) {
       try {
-        const boardLists = await axios.get(`/.netlify/functions/view?type=boardlists&board=${boardId}`)
-        
+        const boardLists = await axios.get(`${NETLIFY_FN_ENDPOINT}/view?type=boardlists&board=${boardId}`)
+
         boardLists.data.forEach(list => {
           if (list.name.indexOf(QUEUE_TITLES.ALERTED) > -1) {
             setqueueAlertIds(listIds => [...listIds, list.id])
@@ -70,7 +70,7 @@ const Index = () => {
             setQueuePendingUrl(location.origin + `/queue?id=${queuePendingId}`)
           }
         })
-        
+
         const lists = {}
         boardLists.data.forEach(list => {
           lists[list.id] = list
@@ -87,8 +87,8 @@ const Index = () => {
    */
   const getQueues = async () => {
     if (queueAlertIds && queueMissedId) {
-      const tickets = await axios.get(`/.netlify/functions/view?type=queues&queueAlertIds=${queueAlertIds.join(',')}&queueMissedId=${queueMissedId}`)
-      
+      const tickets = await axios.get(`${NETLIFY_FN_ENDPOINT}/view?type=queues&queueAlertIds=${queueAlertIds.join(',')}&queueMissedId=${queueMissedId}`)
+
       // Set the missed tickets
       setTicketsMissed(tickets.data.missed[queueMissedId])
 


### PR DESCRIPTION
## Problem

Some users have QR scanner apps that use ephemeral browser instances some as the default iOS QR scanner. This means that they will be unable to rejoin with their previous queue number if they navigate away. 

## Solution

**Features**:

Implement a check server-side before joining, if a user's number is currently in the wait queue it will restore their previous queue number instead of generating a new one.

**Improvements**:

Also included some refactoring to reduce repetition and tweak styling for smaller screen sizes.

